### PR TITLE
Inline dezalgo - RFC

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,8 +1,5 @@
-var dezalgo = require('dezalgo')
-
 module.exports = function (tasks, cb) {
-  if (cb) cb = dezalgo(cb)
-  var results, pending, keys
+  var results, pending, keys, zalgo = true
   if (Array.isArray(tasks)) {
     results = []
     pending = tasks.length
@@ -11,28 +8,34 @@ module.exports = function (tasks, cb) {
     results = {}
     pending = keys.length
   }
+  
+  function done () {
+    if (cb && zalgo) process.nextTick(function () { cb.apply(undefined, arguments) })
+    else if (cb) cb.apply(undefined, arguments)
+    cb = null
+  }
 
-  function done (i, err, result) {
+  function each (i, err, result) {
     results[i] = result
     if (--pending === 0 || err) {
-      if (cb) cb(err, results)
-      cb = null
+      done(err, results)
     }
   }
 
   if (!pending) {
     // empty
-    if (cb) cb(null, results)
-    cb = null
+    done(null, results)
   } else if (keys) {
     // object
     keys.forEach(function (key) {
-      tasks[key](done.bind(undefined, key))
+      tasks[key](each.bind(undefined, key))
     })
   } else {
     // array
     tasks.forEach(function (task, i) {
-      task(done.bind(undefined, i))
+      task(each.bind(undefined, i))
     })
   }
+  
+  zalgo = false
 }

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = function (tasks, cb) {
-  var results, pending, keys, zalgo = true
+  var results, pending, keys
+  var isSync = true
   if (Array.isArray(tasks)) {
     results = []
     pending = tasks.length
@@ -8,11 +9,13 @@ module.exports = function (tasks, cb) {
     results = {}
     pending = keys.length
   }
-  
-  function done () {
-    if (cb && zalgo) process.nextTick(function () { cb.apply(undefined, arguments) })
-    else if (cb) cb.apply(undefined, arguments)
-    cb = null
+
+  function done (err, results) {
+    function end () {
+      cb && cb(err, results)
+      cb = null
+    }
+    isSync ? process.nextTick(end) : end()
   }
 
   function each (i, err, result) {
@@ -36,6 +39,6 @@ module.exports = function (tasks, cb) {
       task(each.bind(undefined, i))
     })
   }
-  
-  zalgo = false
+
+  isSync = false
 }

--- a/package.json
+++ b/package.json
@@ -10,9 +10,7 @@
   "bugs": {
     "url": "https://github.com/feross/run-parallel/issues"
   },
-  "dependencies": {
-    "dezalgo": "^1.0.1"
-  },
+  "dependencies": {},
   "devDependencies": {
     "standard": "^4.3.2",
     "tape": "^4.0.0",


### PR DESCRIPTION
Fixes #6.

```bash
browserify -r run-parallel | wc -l
    393

browserify -r dezalgo | wc -l
    353

browserify -r run-parallel -i node_modules/dezalgo/** | wc -l
     44

C:\Users\Michael\Github\run-parallel>browserify -r ./ | wc -l
    115
# about half of this is the `process` shim
```

I feel like `dezalgo` is a bit hacky, with its synchrony detection.

Request for comments.